### PR TITLE
Add Card Entities and required Enums

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,3 +1,0 @@
-## Asana Link
-
-## Description

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,3 @@
+## Asana Link
+
+## Description

--- a/app/entities/Card.scala
+++ b/app/entities/Card.scala
@@ -1,0 +1,9 @@
+package entities
+import enums._
+
+abstract class Card(
+  val name: String,
+  val card_text: String,
+  val mana_cost: Int,
+  val hero_class: HeroClass,
+  val special_effects: Array[SpecialEffect]) {}

--- a/app/entities/HeroCard.scala
+++ b/app/entities/HeroCard.scala
@@ -1,0 +1,11 @@
+package entities
+import enums._
+
+class HeroCard(
+  name: String,
+  card_text: String,
+  mana_cost: Int,
+  hero_class: HeroClass,
+  special_effects: Array[SpecialEffect],
+  val armor: Int
+) extends Card(name, card_text, mana_cost, hero_class, special_effects) {}

--- a/app/entities/Minion.scala
+++ b/app/entities/Minion.scala
@@ -1,0 +1,12 @@
+package entities
+import enums._
+
+class Minion(
+  name: String,
+  card_text: String,
+  mana_cost: Int,
+  hero_class: HeroClass,
+  special_effects: Array[SpecialEffect],
+  val attack: Int,
+  val defense: Int
+) extends Card(name, card_text, mana_cost, hero_class, special_effects) {}

--- a/app/entities/Spell.scala
+++ b/app/entities/Spell.scala
@@ -1,0 +1,10 @@
+package entities
+import enums._
+
+class Spell(
+  name: String,
+  card_text: String,
+  mana_cost: Int,
+  hero_class: HeroClass,
+  special_effects: Array[SpecialEffect]
+) extends Card(name, card_text, mana_cost, hero_class, special_effects) {}

--- a/app/entities/Weapon.scala
+++ b/app/entities/Weapon.scala
@@ -1,0 +1,12 @@
+package entities
+import enums._
+
+class Weapon(
+  name: String,
+  card_text: String,
+  mana_cost: Int,
+  hero_class: HeroClass,
+  special_effects: Array[SpecialEffect],
+  val attack: Int,
+  val durability: Int
+) extends Card(name, card_text, mana_cost, hero_class, special_effects) {}

--- a/app/entities/enums/HeroClass.scala
+++ b/app/entities/enums/HeroClass.scala
@@ -1,0 +1,7 @@
+package entities.enums
+
+class HeroClass {}
+
+object HeroClass extends Enumeration {
+  val Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior, Neutral = Value
+}

--- a/app/entities/enums/SpecialEffect.scala
+++ b/app/entities/enums/SpecialEffect.scala
@@ -1,0 +1,9 @@
+package entities.enums
+
+class SpecialEffect {}
+
+object SpecialEffect extends Enumeration {
+  val Adapt, Battlecry, Charge, ChooseOne, Combo, Counter, Deathrattle, Discover, DivineShield,
+      Enrage, Freeze, Immune, Inspire, Lifesteal, Mega_Windfury, Overload, Poisonous, Quest,
+      Secret, Silence, Stealth, SpellDamage, Taunt, Windfury = Value
+}


### PR DESCRIPTION
## Asana Link
https://app.asana.com/0/505149144121805/508641797510000
## Description
Added our first entities & enums.

This code is doing more than it seems initially (did a lot of readings on Scala, make sure to look into this stuff too).

The classes primary constructor is taking those parameters, and setting them as immutable members on the class by default because of the val keyword. For the ones that don't have the val keyword, you'll notice that they're being passed to the super class (that happens automatically via the extends call) and there, they're being instantiated automatically.

The equivalent Java code would entail defining a constructor, passing in the variables to the constructor (we did do that here), declaring immutable (final) private members, and then initializing those members in the constructor, as well as declaring getters and setters for those members.

By "equivalent", I really mean equivalent. You can compile this Scala code and decompile it into Java and that's what would be happening.

Ethan did help out here (I couldn't @ him because he might've not joined this group yet), but for the first night he was here for development of this feature, so we have at least two eyes on some of this code.

The code we both worked on was an earlier implementation of Card, Spell, and Minion. And we discussed the domain surrounding this as well, so we were fleshing out ideas before diving in.